### PR TITLE
fix: prevented http client from overriding logs configs

### DIFF
--- a/MergerLogic/Extensions/ServiceCollectionExtensions.cs
+++ b/MergerLogic/Extensions/ServiceCollectionExtensions.cs
@@ -26,13 +26,14 @@ namespace MergerLogic.Extensions
             {
                 collection = collection.RegisterServiceProvider();
             }
+
             return collection
                 .RegisterImageProcessors()
                 .RegisterMergerUtils()
                 .RegisterS3()
+                .RegisterHttp() //registering http override logs configuration so it must be registered before the telemetry 
                 .RegisterOpenTelemetry()
-                .RegisterFileSystem()
-                .RegisterHttp();
+                .RegisterFileSystem();
         }
 
         public static IServiceCollection RegisterImageProcessors(this IServiceCollection collection)


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔/✖                                                                        |
| New feature     | ✔/✖                                                                        |
| Breaking change | ✔/✖                                                                        |
| Deprecations    | ✔/✖                                                                        |
| Documentation   | ✔/✖                                                                        |
| Tests added     | ✔/✖                                                                        |
| Chore            | ✔/✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
please note the the developer logging configuration is still set to info