### PR TITLE
fix: flip internal origin

### DIFF
--- a/MergerLogic/DataTypes/Data.cs
+++ b/MergerLogic/DataTypes/Data.cs
@@ -94,7 +94,7 @@ namespace MergerLogic.DataTypes
                 this.ToCurrentGrid = tile => tile;
             }
             this.GetTile = this.GetTileInitializer;
-            if (this.Origin == GridOrigin.LOWER_LEFT)
+            if (this.Origin == GridOrigin.UPPER_LEFT)
             {
                 this.ConvertOriginTile = tile =>
                 {

--- a/MergerLogicUnitTests/DataTypes/FSTest.cs
+++ b/MergerLogicUnitTests/DataTypes/FSTest.cs
@@ -96,7 +96,7 @@ namespace MergerLogicUnitTests.DataTypes
         {
             this.SetupConstructorRequiredMocks(isBase);
             var seq = new MockSequence();
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .InSequence(seq)
@@ -136,7 +136,7 @@ namespace MergerLogicUnitTests.DataTypes
                     ? Times.Once
                     : Times.Never);
             this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
-                    origin == GridOrigin.LOWER_LEFT
+                    origin == GridOrigin.UPPER_LEFT
                         ? Times.Once
                         : Times.Never);
             this._oneXOneConvertorMock.Verify(converter => converter.TryFromTwoXOne(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
@@ -425,7 +425,7 @@ namespace MergerLogicUnitTests.DataTypes
         {
             this.SetupConstructorRequiredMocks(isBase);
 
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .Setup(utils => utils.FlipY(It.IsAny<Tile>()))
@@ -490,7 +490,7 @@ namespace MergerLogicUnitTests.DataTypes
 
             foreach (var tile in testTiles)
             {
-                if (origin == GridOrigin.LOWER_LEFT)
+                if (origin == GridOrigin.UPPER_LEFT)
                 {
                     this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Tile>(tile, tileComparer)), Times.Once);
                 }
@@ -694,7 +694,7 @@ namespace MergerLogicUnitTests.DataTypes
             this._fsUtilsMock
                 .Setup(utils => utils.GetTile(It.IsAny<Coord>()))
                 .Returns(new Tile(0, 0, 0, Array.Empty<byte>()));
-            if (origin != GridOrigin.UPPER_LEFT)
+            if (origin != GridOrigin.LOWER_LEFT)
             {
                 this._geoUtilsMock
                     .Setup(utils => utils.FlipY(It.IsAny<Tile>()))
@@ -776,7 +776,7 @@ namespace MergerLogicUnitTests.DataTypes
                             .Returns<Tile>(tile => tile.Z != 0 ? tile : null);
                     }
 
-                    if (origin == GridOrigin.LOWER_LEFT && (!isOneXOne || tile.Z != 0))
+                    if (origin == GridOrigin.UPPER_LEFT && (!isOneXOne || tile.Z != 0))
                     {
                         this._geoUtilsMock
                             .InSequence(seq)
@@ -802,7 +802,7 @@ namespace MergerLogicUnitTests.DataTypes
                 {
                     this._pathUtilsMock.Verify(utils => utils.FromPath(It.IsRegex($"^{tile.Z}\\.(png|jpg)$"), false), Times.Once);
                     this._fsUtilsMock.Verify(utils => utils.GetTile(It.Is<Coord>(c => c.Z == tile.Z && c.X == tile.X && c.Y == tile.Y)));
-                    if (origin == GridOrigin.LOWER_LEFT)
+                    if (origin == GridOrigin.UPPER_LEFT)
                     {
                         this._geoUtilsMock.Verify(converter => converter.FlipY(tile), Times.Once);
                     }

--- a/MergerLogicUnitTests/DataTypes/GpkgTest.cs
+++ b/MergerLogicUnitTests/DataTypes/GpkgTest.cs
@@ -82,7 +82,7 @@ namespace MergerLogicUnitTests.DataTypes
         {
             this.SetupRequiredBaseMocks(isBase);
             var seq = new MockSequence();
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .InSequence(seq)
@@ -125,7 +125,7 @@ namespace MergerLogicUnitTests.DataTypes
                     ? Times.Once
                     : Times.Never);
             this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
-                    origin == GridOrigin.LOWER_LEFT
+                    origin == GridOrigin.UPPER_LEFT
                         ? Times.Once
                         : Times.Never);
             this._oneXOneConvertorMock.Verify(converter => converter.TryFromTwoXOne(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
@@ -414,7 +414,7 @@ namespace MergerLogicUnitTests.DataTypes
         {
             this.SetupRequiredBaseMocks(isBase);
 
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .Setup(utils => utils.FlipY(It.IsAny<Tile>()))
@@ -453,7 +453,7 @@ namespace MergerLogicUnitTests.DataTypes
                 tile1?.Y == tile2?.Y);
             foreach (var tile in testTiles)
             {
-                if (origin == GridOrigin.LOWER_LEFT)
+                if (origin == GridOrigin.UPPER_LEFT)
                 {
                     this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Tile>(tile, tileComparer)), Times.Once);
                 }
@@ -670,7 +670,7 @@ namespace MergerLogicUnitTests.DataTypes
             this.SetupRequiredBaseMocks(isBase);
             this._gpkgUtilsMock.Setup(utils => utils.GetBatch(batchSize, It.IsAny<long>()))
                 .Returns(new List<Tile> { new Tile(0, 0, 0, new byte[] { }) });
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock.Setup(converter => converter.FlipY(It.IsAny<Tile>()))
                     .Returns<Tile>(t => t.Y);
@@ -735,7 +735,7 @@ namespace MergerLogicUnitTests.DataTypes
                     .Returns(tileBatches[i].ToList());
                 for (var j = 0; j < tileBatches[i].Length; j++)
                 {
-                    if (origin == GridOrigin.LOWER_LEFT)
+                    if (origin == GridOrigin.UPPER_LEFT)
                     {
                         this._geoUtilsMock
                             .InSequence(seq)
@@ -770,7 +770,7 @@ namespace MergerLogicUnitTests.DataTypes
                 this._gpkgUtilsMock.Verify(utils => utils.GetBatch(batchSize, i * batchSize), Times.Once);
                 foreach (var tile in tileBatches[i])
                 {
-                    if (origin == GridOrigin.LOWER_LEFT)
+                    if (origin == GridOrigin.UPPER_LEFT)
                     {
                         this._geoUtilsMock.Verify(converter => converter.FlipY(tile), Times.Once);
                     }

--- a/MergerLogicUnitTests/DataTypes/S3Test.cs
+++ b/MergerLogicUnitTests/DataTypes/S3Test.cs
@@ -86,7 +86,7 @@ namespace MergerLogicUnitTests.DataTypes
         public void TileExists(Coord cords, bool isOneXOne, GridOrigin origin, bool useCoords)
         {
             var seq = new MockSequence();
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .InSequence(seq)
@@ -126,7 +126,7 @@ namespace MergerLogicUnitTests.DataTypes
                     ? Times.Once
                     : Times.Never);
             this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
-                    origin == GridOrigin.LOWER_LEFT
+                    origin == GridOrigin.UPPER_LEFT
                         ? Times.Once
                         : Times.Never);
             this._oneXOneConvertorMock.Verify(converter => converter.TryFromTwoXOne(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
@@ -413,7 +413,7 @@ namespace MergerLogicUnitTests.DataTypes
             var seq = new MockSequence();
             foreach (var tile in testTiles)
             {
-                if (origin == GridOrigin.LOWER_LEFT)
+                if (origin == GridOrigin.UPPER_LEFT)
                 {
                     this._geoUtilsMock
                         .InSequence(seq)
@@ -447,7 +447,7 @@ namespace MergerLogicUnitTests.DataTypes
             var tileComparer = EqualityComparerFactory.Create<Tile>(tileEqualFunc);
             foreach (var tile in testTiles)
             {
-                if (origin == GridOrigin.LOWER_LEFT)
+                if (origin == GridOrigin.UPPER_LEFT)
                 {
                     this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Tile>(tile, tileComparer)), Times.Once);
                 }
@@ -613,7 +613,7 @@ namespace MergerLogicUnitTests.DataTypes
             this._s3UtilsMock
                 .Setup(utils => utils.GetTile(It.IsAny<string>()))
                 .Returns(new Tile(0, 0, 0, Array.Empty<byte>()));
-            if (origin != GridOrigin.UPPER_LEFT)
+            if (origin != GridOrigin.LOWER_LEFT)
             {
                 this._geoUtilsMock
                     .Setup(utils => utils.FlipY(It.IsAny<Tile>()))
@@ -702,7 +702,7 @@ namespace MergerLogicUnitTests.DataTypes
                         .Returns<Tile>(tile => tile.Z != 0 ? tile : null);
                 }
 
-                if (origin == GridOrigin.LOWER_LEFT && (!isOneXOne || tile.Z != 0))
+                if (origin == GridOrigin.UPPER_LEFT && (!isOneXOne || tile.Z != 0))
                 {
                     this._geoUtilsMock
                         .InSequence(seq)
@@ -747,7 +747,7 @@ namespace MergerLogicUnitTests.DataTypes
                             utils.GetTile($"{tile.Z}/{tile.X}/{tile.Y}.png"));
                     }
 
-                    if (origin == GridOrigin.LOWER_LEFT && (!isOneXOne || tile.Z != 0))
+                    if (origin == GridOrigin.UPPER_LEFT && (!isOneXOne || tile.Z != 0))
                     {
                         this._geoUtilsMock.Verify(converter => converter.FlipY(tile), Times.Once);
                     }

--- a/MergerLogicUnitTests/DataTypes/TMSTest.cs
+++ b/MergerLogicUnitTests/DataTypes/TMSTest.cs
@@ -81,7 +81,7 @@ namespace MergerLogicUnitTests.DataTypes
         {
             this.SetupConstructorRequiredMocks();
             var seq = new MockSequence();
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .InSequence(seq)
@@ -122,7 +122,7 @@ namespace MergerLogicUnitTests.DataTypes
                     ? Times.Once
                     : Times.Never);
             this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
-                    origin == GridOrigin.LOWER_LEFT
+                    origin == GridOrigin.UPPER_LEFT
                         ? Times.Once
                         : Times.Never);
             this._oneXOneConvertorMock.Verify(converter => converter.TryFromTwoXOne(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),

--- a/MergerLogicUnitTests/DataTypes/WMTSTest.cs
+++ b/MergerLogicUnitTests/DataTypes/WMTSTest.cs
@@ -81,7 +81,7 @@ namespace MergerLogicUnitTests.DataTypes
         {
             this.SetupConstructorRequiredMocks();
             var seq = new MockSequence();
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .InSequence(seq)
@@ -122,7 +122,7 @@ namespace MergerLogicUnitTests.DataTypes
                     ? Times.Once
                     : Times.Never);
             this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
-                    origin == GridOrigin.LOWER_LEFT
+                    origin == GridOrigin.UPPER_LEFT
                         ? Times.Once
                         : Times.Never);
             this._oneXOneConvertorMock.Verify(converter => converter.TryFromTwoXOne(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),

--- a/MergerLogicUnitTests/DataTypes/XYZTest.cs
+++ b/MergerLogicUnitTests/DataTypes/XYZTest.cs
@@ -81,7 +81,7 @@ namespace MergerLogicUnitTests.DataTypes
         {
             this.SetupConstructorRequiredMocks();
             var seq = new MockSequence();
-            if (origin == GridOrigin.LOWER_LEFT)
+            if (origin == GridOrigin.UPPER_LEFT)
             {
                 this._geoUtilsMock
                     .InSequence(seq)
@@ -122,7 +122,7 @@ namespace MergerLogicUnitTests.DataTypes
                     ? Times.Once
                     : Times.Never);
             this._geoUtilsMock.Verify(utils => utils.FlipY(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),
-                    origin == GridOrigin.LOWER_LEFT
+                    origin == GridOrigin.UPPER_LEFT
                         ? Times.Once
                         : Times.Never);
             this._oneXOneConvertorMock.Verify(converter => converter.TryFromTwoXOne(It.Is<Coord>(c => c.Z == cords.Z && c.X == cords.X && c.Y == cords.Y)),


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

fix service to work in LL at default