### PR TITLE
fix: issue when updating GPKG tile matrix when tile table is empty

### DIFF
--- a/MergerLogic/Clients/GpkgClient.cs
+++ b/MergerLogic/Clients/GpkgClient.cs
@@ -673,8 +673,9 @@ namespace MergerLogic.Clients
                 connection.Open();
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText = $"SELECT  MAX(zoom_level) AS maxZoom FROM \"{this._tileCache}\";";
-                    maxZoom = int.Parse(command.ExecuteScalar().ToString());
+                    command.CommandText = $"SELECT MAX(zoom_level) AS maxZoom FROM \'{this._tileCache}\';";
+                    var res = command.ExecuteScalar();
+                    maxZoom = res != DBNull.Value ? int.Parse(res.ToString()) : 0;
                 }
 
                 if (isOneXOne)


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |