### PR TITLE
fix: don't ask for 'destination' tile if source tile is null

### DIFF
--- a/MergerLogic/Clients/IGpkgClient.cs
+++ b/MergerLogic/Clients/IGpkgClient.cs
@@ -8,7 +8,7 @@ namespace MergerLogic.Clients
     {
         List<Tile> GetBatch(int batchSize, long offset);
         Extent GetExtent();
-        Tile GetLastTile(int[] coords, int currentTileZoom);
+        Tile? GetLastTile(int[] coords, int currentTileZoom);
         long GetTileCount();
         void InsertTiles(IEnumerable<Tile> tiles);
         void UpdateExtent(Extent extent);

--- a/MergerLogic/DataTypes/Data.cs
+++ b/MergerLogic/DataTypes/Data.cs
@@ -265,17 +265,17 @@ namespace MergerLogic.DataTypes
 
         public Tile? GetCorrespondingTile(Coord coords, bool upscale)
         {
+            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] start for coord: z:{coords.Z}, x:{coords.X}, y:{coords.Y}, upscale: {upscale}");
             Stopwatch stopwatch = Stopwatch.StartNew();
-            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] start for coord: {coords.ToString()}, upscale: {upscale}");
             Tile? correspondingTile = this.GetTile(coords.Z, coords.X, coords.Y);
 
             if (upscale && correspondingTile == null)
             {
                 correspondingTile = this.GetLastExistingTile(coords);
             }
-            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] end for coord: {coords.ToString()}, upscale: {upscale}");
             stopwatch.Stop();
             this._metricsProvider.TotalFetchTimePerTileHistogram(stopwatch.Elapsed.TotalMilliseconds);
+            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] finished for coord: z:{coords.Z}, x:{coords.X}, y:{coords.Y}, upscale: {upscale}");
             return correspondingTile;
         }
 

--- a/MergerLogic/DataTypes/Data.cs
+++ b/MergerLogic/DataTypes/Data.cs
@@ -198,6 +198,7 @@ namespace MergerLogic.DataTypes
 
         protected virtual Tile? InternalGetLastExistingTile(Coord coords)
         {
+            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] started for coord: z:{coords.Z}, x:{coords.X}, y:{coords.Y}");
             int z = coords.Z;
             int baseTileX = coords.X;
             int baseTileY = this.ConvertOriginCoord(coords); //dont forget to use the correct origin when overriding this
@@ -216,7 +217,8 @@ namespace MergerLogic.DataTypes
                     break;
                 }
             }
-
+            string message = lastTile == null ? "null" : $"z:{lastTile.Z}, x:{lastTile.X}, y:{lastTile.Y}";
+            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] ended, lastTile: {message}");
             return lastTile;
         }
 

--- a/MergerLogic/DataTypes/Data.cs
+++ b/MergerLogic/DataTypes/Data.cs
@@ -275,7 +275,8 @@ namespace MergerLogic.DataTypes
             }
             stopwatch.Stop();
             this._metricsProvider.TotalFetchTimePerTileHistogram(stopwatch.Elapsed.TotalMilliseconds);
-            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] finished for coord: z:{coords.Z}, x:{coords.X}, y:{coords.Y}, upscale: {upscale}");
+            string correspondingTileMessage = correspondingTile == null ? "null" : $"z:{correspondingTile.Z}, x:{correspondingTile.X}, y:{correspondingTile.Y}";
+            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] finished for coord: z:{coords.Z}, x:{coords.X}, y:{coords.Y}, correspondingTile: {correspondingTileMessage}, upscale: {upscale}");
             return correspondingTile;
         }
 

--- a/MergerLogic/DataTypes/Gpkg.cs
+++ b/MergerLogic/DataTypes/Gpkg.cs
@@ -128,7 +128,7 @@ namespace MergerLogic.DataTypes
 
         protected override Tile InternalGetLastExistingTile(Coord baseCoords)
         {
-            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] started");
+            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] started for coord: z:{baseCoords.Z}, x:{baseCoords.X}, y:{baseCoords.Y}");
             int cordsLength = baseCoords.Z << 1;
             int[] coords = new int[cordsLength];
 
@@ -145,8 +145,9 @@ namespace MergerLogic.DataTypes
                 coords[arrayIterator + 1] = baseTileY;
             }
 
-            Tile lastTile = this.Utils.GetLastTile(coords, z);
-            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] ended");
+            Tile? lastTile = this.Utils.GetLastTile(coords, z);
+            string message = lastTile == null ? $"[{MethodBase.GetCurrentMethod().Name}] ended, lastTile is null" : $"[{MethodBase.GetCurrentMethod().Name}] ended, lastTile: z:{lastTile.Z}, x:{lastTile.X}, y:{lastTile.Y}";
+            this._logger.LogDebug(message);
             return lastTile;
         }
 

--- a/MergerLogic/DataTypes/Gpkg.cs
+++ b/MergerLogic/DataTypes/Gpkg.cs
@@ -126,7 +126,7 @@ namespace MergerLogic.DataTypes
             }
         }
 
-        protected override Tile InternalGetLastExistingTile(Coord baseCoords)
+        protected override Tile? InternalGetLastExistingTile(Coord baseCoords)
         {
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] started for coord: z:{baseCoords.Z}, x:{baseCoords.X}, y:{baseCoords.Y}");
             int cordsLength = baseCoords.Z << 1;
@@ -146,8 +146,8 @@ namespace MergerLogic.DataTypes
             }
 
             Tile? lastTile = this.Utils.GetLastTile(coords, z);
-            string message = lastTile == null ? $"[{MethodBase.GetCurrentMethod().Name}] ended, lastTile is null" : $"[{MethodBase.GetCurrentMethod().Name}] ended, lastTile: z:{lastTile.Z}, x:{lastTile.X}, y:{lastTile.Y}";
-            this._logger.LogDebug(message);
+            string message = lastTile == null ? "null" : $"z:{lastTile.Z}, x:{lastTile.X}, y:{lastTile.Y}";
+            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod().Name}] ended, lastTile {message}");
             return lastTile;
         }
 

--- a/MergerService/src/run.cs
+++ b/MergerService/src/run.cs
@@ -349,7 +349,6 @@ namespace MergerService.Src
                                         Tile? tile = source.GetCorrespondingTile(coord, shouldUpscale);
                                         correspondingTileBuilders.Add(() => tile);
                                     }
-                                    // Get tile BLOB to be later uploaded
                                     var tileMergeStopwatch = Stopwatch.StartNew();
                                     byte[]? blob = this._tileMerger.MergeTiles(correspondingTileBuilders, coord,
                                         metadata.TargetFormat);

--- a/MergerService/src/run.cs
+++ b/MergerService/src/run.cs
@@ -349,11 +349,10 @@ namespace MergerService.Src
                                         Tile? tile = source.GetCorrespondingTile(coord, shouldUpscale);
                                         correspondingTileBuilders.Add(() => tile);
                                     }
-                                    
+                                    // Get tile BLOB to be later uploaded
                                     var tileMergeStopwatch = Stopwatch.StartNew();
                                     byte[]? blob = this._tileMerger.MergeTiles(correspondingTileBuilders, coord,
                                         metadata.TargetFormat);
-
                                     tileMergeStopwatch.Stop();
                                     this._metricsProvider.MergeTimePerTileHistogram(tileMergeStopwatch.Elapsed.TotalSeconds, metadata.TargetFormat);
 

--- a/MergerService/src/run.cs
+++ b/MergerService/src/run.cs
@@ -271,9 +271,7 @@ namespace MergerService.Src
                 ? (_, _) => null
                 : (source, coord) =>
                 {
-                    this._logger.LogDebug($"[{methodName}] GetCorrespondingTile start for coord {coord.ToString()}, shouldUpscale: {shouldUpscale}");
                     Tile? resultTile = source.GetCorrespondingTile(coord, shouldUpscale);
-                    this._logger.LogDebug($"[{methodName}] GetCorrespondingTile finished resultTile={resultTile}");
                     return resultTile;
                 };
 
@@ -351,17 +349,14 @@ namespace MergerService.Src
                                         Tile? tile = source.GetCorrespondingTile(coord, shouldUpscale);
                                         correspondingTileBuilders.Add(() => tile);
                                     }
-                                    this._logger.LogDebug($"[{methodName}] MergeTiles of {correspondingTileBuilders.Count} tiles");
-
+                                    
                                     var tileMergeStopwatch = Stopwatch.StartNew();
-
                                     byte[]? blob = this._tileMerger.MergeTiles(correspondingTileBuilders, coord,
                                         metadata.TargetFormat);
 
                                     tileMergeStopwatch.Stop();
                                     this._metricsProvider.MergeTimePerTileHistogram(tileMergeStopwatch.Elapsed.TotalSeconds, metadata.TargetFormat);
 
-                                    this._logger.LogInformation($"[{methodName}] MergeTiles finished");
                                     if (blob != null)
                                     {
                                         tiles.Add(new Tile(coord, blob));
@@ -373,7 +368,7 @@ namespace MergerService.Src
                                     // Show progress every batchSize
                                     if (overallTileProgressCount % this._batchSize == 0)
                                     {
-                                        this._logger.LogDebug(
+                                        this._logger.LogInformation(
                                             $"[{methodName}] Job: {task.JobId}, Task: {task.Id}, Tile Count: {overallTileProgressCount} / {totalTileCount}");
                                         UpdateRelativeProgress(task, overallTileProgressCount, totalTileCount, taskUtils);
                                     }


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Don't ask for 'destination' tile if source tile is null
Some logs fixed / added