### PR TITLE
fix: hotfix fail ingestion if get tile fails

### DIFF
--- a/MergerLogic/Clients/S3Client.cs
+++ b/MergerLogic/Clients/S3Client.cs
@@ -53,8 +53,9 @@ namespace MergerLogic.Clients
             }
             catch (AggregateException e)
             {
-                this._logger.LogDebug($"[{methodName}] exception, Message: {e.Message}");
-                return null;
+                string message = $"exception while getting key {key}, Message: {e.Message}";
+                this._logger.LogError($"[{methodName}] {message}");
+                throw new Exception(message, e);
             }
         }
 

--- a/MergerLogicUnitTests/Utils/S3UtilsTest.cs
+++ b/MergerLogicUnitTests/Utils/S3UtilsTest.cs
@@ -131,7 +131,15 @@ namespace MergerLogicUnitTests.Utils
                         tile = s3Utils.GetTile(cords.Z, cords.X, cords.Y);
                         break;
                     case GetTileParamType.String:
-                        tile = s3Utils.GetTile("key");
+                        if(exist)
+                        {
+                            tile = s3Utils.GetTile("key");
+                        } 
+                        else
+                        {
+                            Assert.ThrowsException<Exception>(() => s3Utils.GetTile("key"));
+                            tile = null;
+                        }
                         break;
                 }
 


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

hotfix: fail ingestion if get tile fails