### PR TITLE
fix: exporter written twice in helm (MAPCO-3996)

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,14 +1,27 @@
-name: "Publish Release on Tag Push"
+name: Match chart version and push to ACR
 
 on:
-  workflow_dispatch:
   push:
     tags:
-      - '*'
+      - 'v*'
+
+  workflow_dispatch:
+    inputs:
+      version:
+        required: false
+        type: string
+env:
+  HELM_EXPERIMENTAL_OCI: 1
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  build_and_push:
+  build_and_push_docker:
     runs-on: ubuntu-latest
+    env:
+      Docker_Repository: ${{ secrets.ACR_URL }}/${{ github.event.repository.name }}:${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v2
       - uses: azure/docker-login@v1
@@ -16,11 +29,46 @@ jobs:
           login-server: ${{ secrets.ACR_URL }}
           username: ${{ secrets.ACR_PUSH_USER }}
           password: ${{ secrets.ACR_PUSH_TOKEN }}
-      - name: Build service docker image
-        run: docker build --build-arg VERSION=${{ github.ref_name }} -t ${{ secrets.ACR_URL }}/tiles-merger-service:${{ github.ref_name }} -f MergerService/Dockerfile .
-      - name: Push service docker image
-        run: docker push ${{ secrets.ACR_URL }}/tiles-merger-service:${{ github.ref_name }}
-      - name: Build CLI docker image
-        run: docker build --build-arg VERSION=${{ github.ref_name }} -t ${{ secrets.ACR_URL }}/tiles-merger-cli:${{ github.ref_name }} -f MergerCli/Dockerfile .
-      - name: Push CLI docker image
-        run: docker push ${{ secrets.ACR_URL }}/tiles-merger-cli:${{ github.ref_name }}      
+      - name: downcase repository
+        run: |
+          echo "Docker_Repository=${Docker_Repository,,}" >>${GITHUB_ENV}
+      - run: docker build . -t ${{ env.Docker_Repository }}
+      - run: docker push ${{ env.Docker_Repository }}
+
+  build_and_push_helm:
+    name: publish helm to acr
+    runs-on: ubuntu-latest
+    steps:    
+      - name: checkout repo from latest commit
+        uses: actions/checkout@v2
+
+      - name: install helm
+        uses: Azure/setup-helm@v1
+        with:
+          version: 'v3.6.3'
+
+      - name: login to acr using helm
+        run: |
+          helm registry login ${{ secrets.ACR_URL }} --username ${{ secrets.ACR_PUSH_USER }} --password ${{ secrets.ACR_PUSH_TOKEN }} 
+
+      - name: Get Chart name
+        run: |
+          export "CHART=$(cat Chart.yaml | grep name | awk '{print $2; exit}')"
+          echo "CHART=$CHART" >> $GITHUB_ENV
+        working-directory: ./helm
+
+      - name: Get version 
+        run: |
+          export "VER=$(cat Chart.yaml | grep version | awk '{print $2; exit}')"
+          echo "VER=$VER" >> $GITHUB_ENV
+        working-directory: ./helm
+
+      - name: save helm chart to local registry
+        run: |
+          helm chart save . '${{ secrets.ACR_URL }}/helm/${{ env.CHART }}:${{ env.VER }}'
+        working-directory: ./helm
+      
+      - name: publish chart to acr
+        run: |
+          helm chart push ${{ secrets.ACR_URL }}/helm/${{ env.CHART }}:${{ env.VER }}
+        working-directory: ./helm

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -2,7 +2,11 @@
 Expand the name of the chart.
 */}}
 {{- define "gpkg-merger.name" -}}
+{{- if .Values.isExporter }}
+{{- default (printf "%s-%s" .Chart.Name "exporter") | trunc 63 | trimSuffix "-" }}
+{{- else }}
 {{- default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -2,11 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "gpkg-merger.name" -}}
-{{- if .Values.isExporter }}
-{{- default (printf "%s-%s" .Chart.Name "exporter") | trunc 63 | trimSuffix "-" }}
-{{- else }}
 {{- default .Chart.Name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/templates/_resource.tpl
+++ b/helm/templates/_resource.tpl
@@ -2,33 +2,53 @@
 Create service name as used by the service name label.
 */}}
 {{- define "service.fullname" -}}
+{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "service" | indent 1 }}
+{{- else }}
+{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "service" | indent 1 }}
+{{- end }}
 {{- end }}
 
 {{/*
 Create configmap name as used by the service name label.
 */}}
 {{- define "configmap.fullname" -}}
+{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "configmap" | indent 1 }}
+{{- else }}
+{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "configmap" | indent 1 }}
+{{- end }}
 {{- end }}
 
 {{/*
 Create deployment name as used by the service name label.
 */}}
 {{- define "deployment.fullname" -}}
+{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "deployment" | indent 1 }}
+{{- else }}
+{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "deployment" | indent 1 }}
+{{- end }}
 {{- end }}
 
 {{/*
 Create route name as used by the service name label.
 */}}
 {{- define "route.fullname" -}}
+{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "route" | indent 1 }}
+{{- else }}
+{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "route" | indent 1 }}
+{{- end }}
 {{- end }}
 
 {{/*
 Create ingress name as used by the service name label.
 */}}
 {{- define "ingress.fullname" -}}
+{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "ingress" | indent 1 }}
+{{- else }}
+{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "ingress" | indent 1 }}
+{{- end }}
 {{- end }}

--- a/helm/templates/_resource.tpl
+++ b/helm/templates/_resource.tpl
@@ -2,53 +2,33 @@
 Create service name as used by the service name label.
 */}}
 {{- define "service.fullname" -}}
-{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "service" | indent 1 }}
-{{- else }}
-{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "service" | indent 1 }}
-{{- end }}
 {{- end }}
 
 {{/*
 Create configmap name as used by the service name label.
 */}}
 {{- define "configmap.fullname" -}}
-{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "configmap" | indent 1 }}
-{{- else }}
-{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "configmap" | indent 1 }}
-{{- end }}
 {{- end }}
 
 {{/*
 Create deployment name as used by the service name label.
 */}}
 {{- define "deployment.fullname" -}}
-{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "deployment" | indent 1 }}
-{{- else }}
-{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "deployment" | indent 1 }}
-{{- end }}
 {{- end }}
 
 {{/*
 Create route name as used by the service name label.
 */}}
 {{- define "route.fullname" -}}
-{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "route" | indent 1 }}
-{{- else }}
-{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "route" | indent 1 }}
-{{- end }}
 {{- end }}
 
 {{/*
 Create ingress name as used by the service name label.
 */}}
 {{- define "ingress.fullname" -}}
-{{- if not .Values.isExporter }}
 {{- printf "%s-%s-%s" .Release.Name .Chart.Name "ingress" | indent 1 }}
-{{- else }}
-{{- printf "%s-%s-%s-%s" .Release.Name "exporter" .Chart.Name "ingress" | indent 1 }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


when exported-gpkg is deployed with helm mono-repo, the exporter merger was being deployed in the following way : raster-dev-exporter-exporter-gpkg-merger
