### PR TITLE
fix: fix duplicated wrapup call to same target

### DIFF
--- a/MergerService/Runners/TaskExecutor.cs
+++ b/MergerService/Runners/TaskExecutor.cs
@@ -211,7 +211,6 @@ namespace MergerService.Runners
                         }
 
                         this._logger.LogInformation($"[{methodName}] Overall tile Count: {overallTileProgressCount} / {totalTileCount}");
-                        target.Wrapup();
 
                         mergeRunTimeStopwatch.Stop();
 
@@ -258,6 +257,7 @@ namespace MergerService.Runners
                     }
                     this._metricsProvider.TilesInBatchGauge(0);
                 }
+                target.Wrapup();
             }
             this._logger.LogDebug($"[{methodName}] end");
         }

--- a/MergerServiceUnitTests/Runners/TaskExecutorTest.cs
+++ b/MergerServiceUnitTests/Runners/TaskExecutorTest.cs
@@ -102,13 +102,13 @@ namespace MergerLogicUnitTests.Utils
           tile => testSourceTiles.Any(sourceTile => sourceTile.Z == tile.Z && sourceTile.X == tile.X && sourceTile.Y == tile.Y)
         )
       )), Times.Exactly(numberOfSources));
+      targetDataMock.Verify(targetData => targetData.Wrapup(), Times.Once);
 
       Assert.AreEqual(testSourceTiles.Length, resultWrittenTiles.Count);
       Assert.IsTrue(testSourceTiles.All(
         tile => resultWrittenTiles.Any(sourceTile => sourceTile.Z == tile.Z && sourceTile.X == tile.X && sourceTile.Y == tile.Y)
       ));
     }
-
 
     public static IEnumerable<object[]> GetBatchLimitTestParameters()
     {
@@ -183,12 +183,12 @@ namespace MergerLogicUnitTests.Utils
       testTaskExecutor.ExecuteTask(testTask, _taskUtilsMock.Object, null);
 
       targetDataMock.Verify(targetData => targetData.UpdateTiles(It.IsAny<IEnumerable<Tile>>()), Times.Exactly(amountOfFlushes));
-
+      targetDataMock.Verify(targetData => targetData.Wrapup(), Times.Once);
       Assert.AreEqual(testSourceTiles.Length, resultWrittenTiles.Count);
-      Assert.IsTrue(testSourceTiles.All(
-        tile => resultWrittenTiles.Any(sourceTile => sourceTile.Z == tile.Z && sourceTile.X == tile.X && sourceTile.Y == tile.Y)
-      ));
-    }
+        Assert.IsTrue(testSourceTiles.All(
+            tile => resultWrittenTiles.Any(sourceTile => sourceTile.Z == tile.Z && sourceTile.X == tile.X && sourceTile.Y == tile.Y)
+        ));
+      }
 
     private Tuple<MergeTask, Mock<IData>, Tile[]> SetupTestTask(int amountOfSources, bool isTargetNew)
     {


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Fix bug where wraup method was called twice on same source - caused exception on GPKG source where triggers where created twice