### PR TITLE
fix: changed container name to be taken from chart name

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
     #   nodeSelector:
     #     knownNode: eastus-1-node-1
       containers:
-        - name: {{ $releaseName }}
+        - name: {{ $chartName }}
           {{- with .Values.image }}
           image: {{ $cloudProviderDockerRegistryUrl }}{{ .repository }}:{{ .tag }}
           {{- end }}


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |


Further  information:
<!--
Here you can provide more information regarding any of the questions written above.
In addition, you can add screenshots, ask the maintainers questions.
-->
Changed container name to be taken from chart name instead of release name, so it will be "gpkg-merger" instead of "raster" in umbrella deployments. I made sure it works by running "helm template". 
