### PR TITLE
fix: AWS values loaded only when tiles provider is S3(MAPCO-4564)

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gpkg-merger
 description: A Helm chart for gpkg-merger service # refers to MergerService
 type: application
-version: 1.3.8
-appVersion: 1.3.8
+version: 1.3.9
+appVersion: 1.3.9

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -9,6 +9,7 @@
 {{- if .Values.enabled -}}
 {{- $s3 := (include "common.s3.merged" .) | fromYaml }}
 {{- $fs := (include "common.fs.merged" .) | fromYaml }}
+{{- $storage := (include "common.storage.merged" .) | fromYaml }}
 {{ $gpkgPath := (printf "%s%s" "/app/tiles_outputs/" $fs.internalPvc.gpkgSubPath) }}
 {{ $tilePath := (printf "%s%s" "/app/tiles_outputs/" $fs.internalPvc.tilesSubPath) }}
 {{ $sources := (ternary $tilePath (printf "%s%s" "/layerSources/" $fs.ingestionSourcePvc.subPath) .Values.isExporter ) }}
@@ -101,6 +102,7 @@ spec:
               value: {{ .Values.env.general.batchMaxBytes | int64 | quote }}
             - name: GENERAL__filePath
               value: {{ $tilePath }}
+            {{- if eq $storage.tilesStorageProvider "S3"}}  
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -111,6 +113,7 @@ spec:
                 secretKeyRef:
                   name: {{ $s3.secretName }}
                   key: secretAccessKey
+            {{- end }}      
           envFrom:
             - configMapRef:
                 name: {{ $configmapName }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,7 @@ global:
   environment: ""
   useNodeAffinity: false
   storage:
+    tilesStorageProvider: ""
     fs:
       ingestionSourcePvc:
         name: ""
@@ -53,6 +54,7 @@ serviceUrls:
   heartbeatManager: ""
 
 storage:
+  tilesStorageProvider: ""
   fs:
     ingestionSourcePvc:
       name: ""


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

AWS attributes are set only when tilesProvider is set to S3

