### PR TITLE
fix: made heartbeat client delete heartbeat after completing (MAPCO-5927)

### DIFF
--- a/MergerLogic/Clients/HeartbeatClient.cs
+++ b/MergerLogic/Clients/HeartbeatClient.cs
@@ -64,8 +64,9 @@ namespace MergerLogic.Clients
             }
             catch (Exception e)
             {
-                this._logger.LogError($"[{MethodBase.GetCurrentMethod().Name}] Could not delete heartbeat for task={this._taskId}, {e.Message}");
-                throw;
+                string message = ($"[{MethodBase.GetCurrentMethod().Name}] Could not delete heartbeat for task={this._taskId}, {e.Message}");
+                this._logger.LogError(message);
+                throw new Exception(message, e);
             }
             finally
             {

--- a/MergerLogic/Clients/HeartbeatClient.cs
+++ b/MergerLogic/Clients/HeartbeatClient.cs
@@ -49,6 +49,12 @@ namespace MergerLogic.Clients
 
         public void Stop()
         {
+            if (!this._timer.Enabled)
+            {
+                throw new Exception($"[{MethodBase.GetCurrentMethod().Name}] Heartbeat interval must be running in order to stop it.");
+            }
+            this._logger.LogInformation($"[{MethodBase.GetCurrentMethod().Name}] Stops heartbeats for taskId={this._taskId}");
+            this._timer.Stop();
             try
             {
                 string relativeUri = $"heartbeat/remove";
@@ -63,12 +69,6 @@ namespace MergerLogic.Clients
             }
             finally
             {
-                if (!this._timer.Enabled)
-                {
-                    throw new Exception($"[{MethodBase.GetCurrentMethod().Name}] Heartbeat interval must be running in order to stop it.");
-                }
-                this._logger.LogInformation($"[{MethodBase.GetCurrentMethod().Name}] Stops heartbeats for taskId={this._taskId}");
-                this._timer.Stop();
                 this._taskId = null;
             }
         }

--- a/MergerLogic/Clients/HeartbeatClient.cs
+++ b/MergerLogic/Clients/HeartbeatClient.cs
@@ -1,7 +1,10 @@
 using MergerLogic.Utils;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System.Reflection;
+using System.Text;
 using System.Timers;
+using System.Net.Http.Json;
 
 namespace MergerLogic.Clients
 {
@@ -27,14 +30,16 @@ namespace MergerLogic.Clients
             this._timer.Elapsed += this.Send;
         }
 
-        ~HeartbeatClient() {
+        ~HeartbeatClient()
+        {
             this._timer.Elapsed -= this.Send;
             this._timer.Dispose();
         }
 
         public void Start(string taskId)
         {
-            if (this._timer.Enabled) {
+            if (this._timer.Enabled)
+            {
                 this.Stop();
             }
             this._logger.LogInformation($"[{MethodBase.GetCurrentMethod().Name}] Starting heartbeat for task={taskId}");
@@ -44,13 +49,28 @@ namespace MergerLogic.Clients
 
         public void Stop()
         {
-            if (!this._timer.Enabled)
+            try
             {
-                throw new Exception($"[{MethodBase.GetCurrentMethod().Name}] Heartbeat interval must be running in order to stop it.");
+                string relativeUri = $"heartbeat/remove";
+                string url = new Uri(new Uri(this._baseUrl), relativeUri).ToString();
+                var content = JsonContent.Create(new[] { this._taskId });
+                this._httpClient.PostData(url, content);
             }
-            this._logger.LogInformation($"[{MethodBase.GetCurrentMethod().Name}] Stops heartbeats for taskId={this._taskId}");
-            this._timer.Stop();
-            this._taskId = null;
+            catch (Exception e)
+            {
+                this._logger.LogError($"[{MethodBase.GetCurrentMethod().Name}] Could not delete heartbeat for task={this._taskId}, {e.Message}");
+                throw;
+            }
+            finally
+            {
+                if (!this._timer.Enabled)
+                {
+                    throw new Exception($"[{MethodBase.GetCurrentMethod().Name}] Heartbeat interval must be running in order to stop it.");
+                }
+                this._logger.LogInformation($"[{MethodBase.GetCurrentMethod().Name}] Stops heartbeats for taskId={this._taskId}");
+                this._timer.Stop();
+                this._taskId = null;
+            }
         }
 
         public void Send(object? sender, ElapsedEventArgs elapsedEventArgs)
@@ -66,7 +86,6 @@ namespace MergerLogic.Clients
                 this._logger.LogError($"[{MethodBase.GetCurrentMethod().Name}] Could not send heartbeat for task={this._taskId}, {e.Message}");
                 throw;
             }
-
         }
     }
 }

--- a/MergerLogic/Clients/HeartbeatClient.cs
+++ b/MergerLogic/Clients/HeartbeatClient.cs
@@ -64,7 +64,7 @@ namespace MergerLogic.Clients
             }
             catch (Exception e)
             {
-                string message = ($"[{MethodBase.GetCurrentMethod().Name}] Could not delete heartbeat for task={this._taskId}, {e.Message}");
+                string message = $"[{MethodBase.GetCurrentMethod().Name}] Could not delete heartbeat for task={this._taskId}, {e.Message}";
                 this._logger.LogError(message);
                 throw new Exception(message, e);
             }


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
<!--
Here you can provide more information regarding any of the questions written above.
In addition, you can add screenshots, ask the maintainers questions.
-->
This fixes the bug that after completion the job would go back to Pending before being completed
