### PR TITLE
perf(image): remove per-pixel allocs + redundant merged-image copy (MAPCO-11321)

### DIFF
--- a/MergerLogic/ImageProcessing/TileMerger.cs
+++ b/MergerLogic/ImageProcessing/TileMerger.cs
@@ -57,15 +57,15 @@ namespace MergerLogic.ImageProcessing
                         }
 
                         this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] {imageCollection.Count} where found for merge, start 'imageMagic' merging");
-                        using (var mergedImage = imageCollection.Flatten(MagickColor.FromRgba(0, 0, 0, 0)))
-                        {
-                            ImageFormatter.RemoveImageDateAttributes(mergedImage);
+                        // Flatten returns an image independent of the collection, so it outlives the
+                        // collection's disposal without an extra full-image copy.
+                        IMagickImage<byte> mergedImage = imageCollection.Flatten(MagickColor.FromRgba(0, 0, 0, 0))!;
+                        ImageFormatter.RemoveImageDateAttributes(mergedImage);
 
-                            mergedImage.ColorSpace = ColorSpace.sRGB;
-                            mergedImage.ColorType = mergedImage.HasAlpha ? ColorType.TrueColorAlpha : ColorType.TrueColor;
-                            image = new MagickImage(mergedImage);
-                            this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] 'imageMagic' merging finished");
-                        }
+                        mergedImage.ColorSpace = ColorSpace.sRGB;
+                        mergedImage.ColorType = mergedImage.HasAlpha ? ColorType.TrueColorAlpha : ColorType.TrueColor;
+                        image = mergedImage;
+                        this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] 'imageMagic' merging finished");
                     }
                     break;
             }

--- a/MergerLogic/ImageProcessing/TileScaler.cs
+++ b/MergerLogic/ImageProcessing/TileScaler.cs
@@ -85,12 +85,16 @@ namespace MergerLogic.ImageProcessing
                     int maxRowOffset = TILE_SIZE * scaledChannels;
                     int pixelRowBytes = TILE_SIZE * channels;
 
+                    // Read the whole source pixel buffer once instead of allocating a byte[] per source pixel.
+                    var srcValues = srcPixels.GetValues()!;
+                    int srcStride = baseImage.Width * channels;
+
                     //loop relevant source pixels
                     for (int i = pixelX; i < maxSrcX; i++)
                     {
                         for (int j = pixelY; j < maxSrcY; j++)
                         {
-                            var srcPixel = srcPixels.GetValue(i, j);
+                            int srcPixelIdx = (j * srcStride) + (i * channels);
                             var targetXStart = (i - pixelX) * scale;
                             var targetYStart = (j - pixelY) * scale;
                             var targetPixelIdxStart = (targetXStart + (TILE_SIZE * targetYStart)) * channels;
@@ -99,7 +103,7 @@ namespace MergerLogic.ImageProcessing
                                 for (int pixelRowOffset = 0; pixelRowOffset < maxRowOffset; pixelRowOffset += pixelRowBytes)
                                 {
                                     int pixelIdx = targetPixelIdxStart + pixelColOffset + pixelRowOffset;
-                                    srcPixel!.CopyTo(pixels, pixelIdx); //copy all channels 
+                                    Array.Copy(srcValues, srcPixelIdx, pixels, pixelIdx, channels); //copy all channels
                                 }
                             }
                         }


### PR DESCRIPTION
LOGIC-2 of MAPCO-11317. Native image-path allocation cleanup — no read-API changes.

## Changes
- **TileScaler.Upscale**: the nested scaling loop called `srcPixels.GetValue(i,j)`, which allocates a `byte[]` per source pixel. Now reads the whole source buffer once with `GetValues()` and copies by offset — one allocation instead of one-per-pixel.
- **TileMerger.MergeTiles**: `Flatten()` returns an image independent of the collection, so the merged image no longer gets cloned into a `new MagickImage(...)` just to outlive the `using` scope.

## Output is byte-identical
The `TileScaler`/`TileMerger` golden-image tests (reference upscaled/merged jpegs & pngs) pass unchanged. Full suite: **1141 passed, 0 failed**.

## Scope note
The deeper encode→decode→encode round-trip in the merge path is coupled to `GetTileFormat`'s opaque→jpeg behavior, which is **MAPCO-4731**'s concern. Left untouched here to keep format-selection semantics out of this PR. #175 (MAPCO-8749, format-threading) also overlaps this area and is intentionally not folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)