### PR TITLE
perf(s3): LIST-based existence + parallel tile upload (MAPCO-11322)

### DIFF
--- a/MergerLogic/Clients/S3Client.cs
+++ b/MergerLogic/Clients/S3Client.cs
@@ -5,6 +5,7 @@ using MergerLogic.DataTypes;
 using MergerLogic.ImageProcessing;
 using MergerLogic.Utils;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Reflection;
 
 namespace MergerLogic.Clients
@@ -154,23 +155,12 @@ namespace MergerLogic.Clients
             string methodName = MethodBase.GetCurrentMethod().Name;
             string keyPrefix = this._pathUtils.GetTilePathWithoutExtension(this.path, z, x, y, true);
 
-            try
-            {
-                var getRequest = new GetObjectRequest { BucketName = this._bucket, Key = keyPrefix };
-                var getObjectTask = this._client.GetObjectAsync(getRequest);
-                string result = getObjectTask.Result.Key;
-                return result;
-            }
-            catch (AggregateException e)
-            {
-                if (IsKeyError(e))
-                {
-                    this._logger.LogDebug($"[{methodName}] error getting key: {e.Message}");
-                    return null;
-                }
-                // In case there are other errors such as connection to S3
-                throw e;
-            }
+            // A single prefixed LIST (MaxKeys=1) resolves existence and the real extension without
+            // downloading the object body the way GetObject did.
+            var listRequest = new ListObjectsV2Request { BucketName = this._bucket, Prefix = keyPrefix, MaxKeys = 1 };
+            this._logger.LogDebug($"[{methodName}] ListObjectsV2Async BucketName: {this._bucket}, Prefix: {keyPrefix}");
+            var listObjectsTask = this._client.ListObjectsV2Async(listRequest);
+            return listObjectsTask.Result.S3Objects.FirstOrDefault()?.Key;
         }
     }
 }

--- a/MergerLogic/DataTypes/S3.cs
+++ b/MergerLogic/DataTypes/S3.cs
@@ -198,8 +198,8 @@ namespace MergerLogic.DataTypes
         protected override void InternalUpdateTiles(IEnumerable<Tile> targetTiles)
         {
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] start");
-            // Materialize first so the upstream (single-threaded) grid/origin projection runs before the
-            // uploads fan out; the S3 client and its PutObject calls are independent per tile.
+            // ToList so Parallel.ForEach range-partitions instead of running the upstream grid/origin
+            // projection under the shared-enumerator lock a bare IEnumerable would impose.
             Parallel.ForEach(targetTiles.ToList(), tile => this.Utils.UpdateTile(tile));
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] end");
         }

--- a/MergerLogic/DataTypes/S3.cs
+++ b/MergerLogic/DataTypes/S3.cs
@@ -198,10 +198,9 @@ namespace MergerLogic.DataTypes
         protected override void InternalUpdateTiles(IEnumerable<Tile> targetTiles)
         {
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] start");
-            foreach (var tile in targetTiles)
-            {
-                this.Utils.UpdateTile(tile);
-            }
+            // Materialize first so the upstream (single-threaded) grid/origin projection runs before the
+            // uploads fan out; the S3 client and its PutObject calls are independent per tile.
+            Parallel.ForEach(targetTiles.ToList(), tile => this.Utils.UpdateTile(tile));
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] end");
         }
     }

--- a/MergerLogic/Extensions/ServiceCollectionExtensions.cs
+++ b/MergerLogic/Extensions/ServiceCollectionExtensions.cs
@@ -107,6 +107,11 @@ namespace MergerLogic.Extensions
                     MaxErrorRetry = retries,
                 };
 
+                // Raise the per-endpoint connection cap so parallel tile PUTs are not serialized on the
+                // default limit (2). Set once, before the client's HTTP stack is created.
+                System.Net.ServicePointManager.DefaultConnectionLimit =
+                    Math.Max(System.Net.ServicePointManager.DefaultConnectionLimit, 100);
+
                 var credentials = new BasicAWSCredentials(accessKey, secretKey);
                 return new AmazonS3Client(credentials, s3Config);
             });

--- a/MergerLogic/Extensions/ServiceCollectionExtensions.cs
+++ b/MergerLogic/Extensions/ServiceCollectionExtensions.cs
@@ -107,11 +107,6 @@ namespace MergerLogic.Extensions
                     MaxErrorRetry = retries,
                 };
 
-                // Raise the per-endpoint connection cap so parallel tile PUTs are not serialized on the
-                // default limit (2). Set once, before the client's HTTP stack is created.
-                System.Net.ServicePointManager.DefaultConnectionLimit =
-                    Math.Max(System.Net.ServicePointManager.DefaultConnectionLimit, 100);
-
                 var credentials = new BasicAWSCredentials(accessKey, secretKey);
                 return new AmazonS3Client(credentials, s3Config);
             });

--- a/MergerLogicUnitTests/DataTypes/S3Test.cs
+++ b/MergerLogicUnitTests/DataTypes/S3Test.cs
@@ -473,8 +473,9 @@ namespace MergerLogicUnitTests.DataTypes
 
                 if (!isOneXOne || tile.Z != 7)
                 {
+                    // Uploads run in parallel after the (ordered) grid/origin projection, so UpdateTile is
+                    // intentionally outside the strict sequence; per-tile Times.Once is verified below.
                     this._s3UtilsMock
-                        .InSequence(seq)
                         .Setup(utils => utils.UpdateTile(It.IsAny<Tile>()));
                 }
             }

--- a/MergerLogicUnitTests/Utils/S3UtilsTest.cs
+++ b/MergerLogicUnitTests/Utils/S3UtilsTest.cs
@@ -330,24 +330,17 @@ namespace MergerLogicUnitTests.Utils
                         .Setup(utils => utils.GetTilePathWithoutExtension("test", 0, 0, 0, true))
                         .Returns("key");
 
+            var listResponse = new ListObjectsV2Response();
             if (exist)
             {
-                this._amazonS3ClientMock
-                .InSequence(seq)
-                .Setup(s3 => s3.GetObjectAsync(It.Is<GetObjectRequest>(req =>
-                        req.BucketName == "bucket" && req.Key == "key"),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new GetObjectResponse() { Key = "key" });
+                listResponse.S3Objects.Add(new S3Object() { Key = "key" });
             }
-            else
-            {
-                this._amazonS3ClientMock
+            this._amazonS3ClientMock
                 .InSequence(seq)
-                .Setup(s3 => s3.GetObjectAsync(It.Is<GetObjectRequest>(req =>
-                        req.BucketName == "bucket" && req.Key == "key"),
+                .Setup(s3 => s3.ListObjectsV2Async(It.Is<ListObjectsV2Request>(req =>
+                        req.BucketName == "bucket" && req.Prefix == "key" && req.MaxKeys == 1),
                     It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new AmazonS3Exception("", Amazon.Runtime.ErrorType.Unknown, "NoSuchKey", "", System.Net.HttpStatusCode.NoContent));
-            }
+                .ReturnsAsync(listResponse);
 
             var s3Utils = new S3Client(this._amazonS3ClientMock.Object, this._pathUtilsMock.Object,
                 this._geoUtilsMock.Object, this._loggerMock.Object, "STANDARD", "bucket", "test");
@@ -355,8 +348,8 @@ namespace MergerLogicUnitTests.Utils
             Assert.AreEqual(exist, s3Utils.TileExists(0, 0, 0));
 
             this._pathUtilsMock.Verify(utils => utils.GetTilePathWithoutExtension("test", 0, 0, 0, true), Times.Once);
-            this._amazonS3ClientMock.Verify(s3 => s3.GetObjectAsync(It.Is<GetObjectRequest>(req =>
-                        req.BucketName == "bucket" && req.Key == "key"), It.IsAny<CancellationToken>()), Times.Once);
+            this._amazonS3ClientMock.Verify(s3 => s3.ListObjectsV2Async(It.Is<ListObjectsV2Request>(req =>
+                        req.BucketName == "bucket" && req.Prefix == "key" && req.MaxKeys == 1), It.IsAny<CancellationToken>()), Times.Once);
             this.VerifyAll();
         }
 


### PR DESCRIPTION
LOGIC-3 of MAPCO-11317. Scoped S3 I/O wins.

## Scope decision
"Async end-to-end" taken literally would convert the whole tile pipeline (`IDataUtils`/`IData`/`ITileMerger`/`Process`/`TaskExecutor`) to async — a large rewrite that collides with SVC-1 and the other PRs. This PR delivers the **self-contained** I/O wins and leaves full pipeline-async as a follow-up.

## Changes
- **LIST-based existence** — `S3Client.GetTileKey` (used by `TileExists`) did a full `GetObjectAsync`, downloading the entire object body just to read its `.Key`. Now a single prefixed `ListObjectsV2` with `MaxKeys=1` — existence + real extension, no body transfer.
- **Parallel upload** — `S3.InternalUpdateTiles` uploaded tiles one blocking `PutObject` at a time. Now `Parallel.ForEach`, materializing tiles first so the single-threaded grid/origin projection completes before uploads fan out. (#112 attempted this via `Task.Run(...).Wait()`, which isn't actually parallel; this supersedes it.)
- **Removed no-op connection cap** — dropped a `ServicePointManager.DefaultConnectionLimit` line that was added alongside the parallel upload. `ServicePointManager` governs the legacy `HttpWebRequest` stack; on net6 the AWS SDK's `HttpClient`/`SocketsHttpHandler` ignores it, so it never capped anything. Pure dead-code removal.

## Deferred (follow-ups) — tracked in MAPCO-11364
- **P4** — full end-to-end async of the read/write path (sync-over-async `.Result`).
- **P5r** — `GetTile` still probes Jpeg-then-Png (up to 2 full GETs/tile); the speculative probe was not dropped. (Only `GetTileKey`/`TileExists` moved to LIST here.)
- **P10r** — download parallelism; only uploads are parallelized in this PR.
- **P11** — ctor issues 25 LIST calls (`FolderExists` loop 0..24) to discover the zoom set → single `ListObjectsV2` with `Delimiter="/"`.
- **P14** — HTTP/FS clients' own async/existence tuning (kept out to bound this PR to S3).
- **P15** — upload-concurrency bound. With the no-op cap gone, the upload `Parallel.ForEach` has no deliberate ceiling: concurrency tracks ThreadPool sizing (blocking `PutObject` bodies) and socket count is unbounded (`SocketsHttpHandler.MaxConnectionsPerServer` default = `int.MaxValue`). Follow-up adds a config-driven `MaxDegreeOfParallelism` paired with `AmazonS3Config.MaxConnectionsPerServer` (the real net6 lever), value from a load test.

Note: parent ticket P5 specified HEAD (`GetObjectMetadataAsync`) for existence; this PR chose LIST instead. HEAD-vs-LIST to be settled consistently in MAPCO-11364.

## Testing
Full suite: **1141 passed, 0 failed**. `TileExists` client test drives `ListObjectsV2`; the S3 `UpdateTiles` data-type test no longer sequences `UpdateTile` (uploads are unordered) but still asserts one upload per tile.

## Supersedes / relates
- Supersedes #112 (parallel S3 put).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
