### PR TITLE
fix: config traversal, timer rethrow, stack-trace reset, lock scope (MAPCO-11323)

### DIFF
--- a/MergerLogic/Clients/HeartbeatClient.cs
+++ b/MergerLogic/Clients/HeartbeatClient.cs
@@ -84,8 +84,9 @@ namespace MergerLogic.Clients
             }
             catch (Exception e)
             {
+                // Elapsed runs on a timer thread; the Timer discards anything thrown here and an
+                // unhandled exception can tear down the process. Log and let the next tick retry.
                 this._logger.LogError($"[{MethodBase.GetCurrentMethod().Name}] Could not send heartbeat for task={this._taskId}, {e.Message}");
-                throw;
             }
         }
     }

--- a/MergerLogic/Clients/S3Client.cs
+++ b/MergerLogic/Clients/S3Client.cs
@@ -75,7 +75,7 @@ namespace MergerLogic.Clients
                     return null;
                 }
                 // In case there are other errors such as connection to S3
-                throw e;
+                throw;
             }
         }
 
@@ -169,7 +169,7 @@ namespace MergerLogic.Clients
                     return null;
                 }
                 // In case there are other errors such as connection to S3
-                throw e;
+                throw;
             }
         }
     }

--- a/MergerLogic/DataTypes/Fs.cs
+++ b/MergerLogic/DataTypes/Fs.cs
@@ -16,7 +16,7 @@ namespace MergerLogic.DataTypes
         private IFileSystem _fileSystem;
 
         private readonly string[] _supportedFileExtensions = { ".png", ".jpg", ".jpeg" };
-        static readonly object _locker = new object();
+        private readonly object _locker = new object();
 
         public FS(IPathUtils pathUtils, IServiceProvider container, string path, int batchSize, Grid? grid, GridOrigin? origin, bool isBase = false)
             : base(container, DataType.FOLDER, path, batchSize, grid, origin, isBase)

--- a/MergerLogic/DataTypes/Gpkg.cs
+++ b/MergerLogic/DataTypes/Gpkg.cs
@@ -11,7 +11,7 @@ namespace MergerLogic.DataTypes
         private long _offset;
         private Extent _extent;
         private readonly IConfigurationManager _configManager;
-        static readonly object _locker = new object();
+        private readonly object _locker = new object();
 
         public Gpkg(IConfigurationManager configuration, IServiceProvider container,
             string path, int batchSize, Grid? grid, GridOrigin? origin, bool isBase = false, Extent? extent = null)

--- a/MergerLogic/DataTypes/S3.cs
+++ b/MergerLogic/DataTypes/S3.cs
@@ -17,7 +17,7 @@ namespace MergerLogic.DataTypes
         private IEnumerator<int> _zoomEnumerator;
         private string? _continuationToken;
         private bool _endOfRead;
-        static readonly object _locker = new object();
+        private readonly object _locker = new object();
         private const string nullStringValue = "Null";
 
         private readonly IPathUtils _pathUtils;

--- a/MergerLogic/Utils/ConfigurationManager.cs
+++ b/MergerLogic/Utils/ConfigurationManager.cs
@@ -25,13 +25,8 @@ namespace MergerLogic.Utils
 
         public IEnumerable<IConfigurationSection> GetChildren(params string[] configPath)
         {
-            var section = this.config.GetSection(configPath[0]);
-            for (int i = 1; i < configPath.Length; i++)
-            {
-                // Traverse into the accumulated section, not back to the root each iteration.
-                section = section.GetSection(configPath[i]);
-            }
-            return section.GetChildren();
+            string key = string.Join(":", configPath);
+            return this.config.GetSection(key).GetChildren();
         }
 
         public string GetConfiguration(params string[] configPath)

--- a/MergerLogic/Utils/ConfigurationManager.cs
+++ b/MergerLogic/Utils/ConfigurationManager.cs
@@ -25,12 +25,13 @@ namespace MergerLogic.Utils
 
         public IEnumerable<IConfigurationSection> GetChildren(params string[] configPath)
         {
-            var config = this.config.GetSection(configPath[0]);
-            for (int i = 1; i < configPath.Length - 1; i++)
+            var section = this.config.GetSection(configPath[0]);
+            for (int i = 1; i < configPath.Length; i++)
             {
-                config = this.config.GetSection(configPath[i]);
+                // Traverse into the accumulated section, not back to the root each iteration.
+                section = section.GetSection(configPath[i]);
             }
-            return config.GetSection(configPath[configPath.Length - 1]).GetChildren();
+            return section.GetChildren();
         }
 
         public string GetConfiguration(params string[] configPath)


### PR DESCRIPTION
LOGIC-4 of MAPCO-11317. Four independent correctness fixes.

## Fixes
1. **Config traversal** — `ConfigurationManager.GetChildren` walked from the root section on every loop iteration (not the accumulated section) and its bounds re-applied the final key. Works for 2-part paths — which is the only current caller, `GetChildren("TASK","types")` — but silently wrong for 1-part and 3+-part paths. Now traverses the accumulated section.
2. **Timer rethrow** — `HeartbeatClient.Send` is a `Timer.Elapsed` handler that rethrew on failure. `System.Timers.Timer` discards it, and an unhandled exception on the timer thread can tear down the process. Now logs and lets the next tick retry.
3. **Stack-trace reset** — `S3Client` used `throw e;` on its non-key error paths, resetting the exception's stack trace. Changed to `throw;`.
4. **Lock scope** — `Gpkg`/`Fs`/`S3` held their batch `_locker` as `static`, so every data-source instance serialized paging against every other instance. The guarded state is per-instance, so the lock is now per-instance. Also unblocks parallelism for SVC-1 (MAPCO-11325).

## Testing
Full suite: **1141 passed, 0 failed**. Fixes 1 and 4 preserve current behavior for existing call sites (2-part config path; single-instance paging) while correcting the latent/ cross-instance cases; 2 and 3 change only failure-path behavior. `ConfigurationManager` builds its `IConfiguration` from files in its ctor and isn't injectable, so `GetChildren` has no isolated unit test; the fix is exercised via the `TaskRunner` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)