### PR TITLE
chore: ImageMagick resource caps + server GC (MAPCO-11324)

### DIFF
--- a/MergerLogic/Extensions/ServiceCollectionExtensions.cs
+++ b/MergerLogic/Extensions/ServiceCollectionExtensions.cs
@@ -43,6 +43,12 @@ namespace MergerLogic.Extensions
 
         public static IServiceCollection RegisterImageProcessors(this IServiceCollection collection)
         {
+            // Tiles are already processed in parallel at the app level, so keep ImageMagick single-threaded
+            // per operation to avoid thread oversubscription, and cap its native memory so one large image
+            // cannot exhaust the host.
+            ImageMagick.ResourceLimits.Thread = 1;
+            ImageMagick.ResourceLimits.LimitMemory(new ImageMagick.Percentage(50));
+
             return collection
                 .AddSingleton<ITileMerger, TileMerger>()
                 .AddSingleton<ITileScaler, TileScaler>();

--- a/MergerLogic/Extensions/ServiceCollectionExtensions.cs
+++ b/MergerLogic/Extensions/ServiceCollectionExtensions.cs
@@ -26,6 +26,8 @@ namespace MergerLogic.Extensions
     {
         public static IServiceCollection RegisterMergerLogicType(this IServiceCollection collection, bool includeServiceProvider = true)
         {
+            ConfigureImageMagick();
+
             if (includeServiceProvider)
             {
                 collection = collection.RegisterServiceProvider();
@@ -43,15 +45,18 @@ namespace MergerLogic.Extensions
 
         public static IServiceCollection RegisterImageProcessors(this IServiceCollection collection)
         {
-            // Tiles are already processed in parallel at the app level, so keep ImageMagick single-threaded
-            // per operation to avoid thread oversubscription, and cap its native memory so one large image
-            // cannot exhaust the host.
-            ImageMagick.ResourceLimits.Thread = 1;
-            ImageMagick.ResourceLimits.LimitMemory(new ImageMagick.Percentage(50));
-
             return collection
                 .AddSingleton<ITileMerger, TileMerger>()
                 .AddSingleton<ITileScaler, TileScaler>();
+        }
+
+        // Process-global ImageMagick tuning. Applied once at composition root, kept out of the DI
+        // registration methods so runtime side effects aren't hidden behind a "register services" call.
+        private static void ConfigureImageMagick()
+        {
+            // Tiles are already processed in parallel at the app level, so keep ImageMagick single-threaded
+            // per operation to avoid thread oversubscription.
+            ImageMagick.ResourceLimits.Thread = 1;
         }
 
         public static IServiceCollection RegisterMergerUtils(this IServiceCollection collection)

--- a/MergerService/MergerService.csproj
+++ b/MergerService/MergerService.csproj
@@ -5,6 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+    <!-- Throughput-oriented GC for the long-running, allocation-heavy merge service. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />


### PR DESCRIPTION
LOGIC-5 of MAPCO-11317. Resource-limit hygiene.

## Changes
- **ImageMagick threading** — `ResourceLimits.Thread = 1`. Tiles are already parallelized at the app level, so Magick's per-image OpenMP threading only oversubscribes (N app threads × M Magick threads) and adds sync overhead on 256×256 tiles. Set once at the composition root via a dedicated `ConfigureImageMagick()` — kept out of `RegisterImageProcessors` so this process-global side effect isn't hidden behind a DI "register services" call.
- **Server GC** — `ServerGarbageCollection` / `ConcurrentGarbageCollection` set explicitly in `MergerService.csproj`. These are **no-ops at runtime** — `Microsoft.NET.Sdk.Web` already defaults both to `true` — so this only pins the intent (documents it, and survives a future SDK/host change that would otherwise drop it). No behavior change.

## Removed
- **`LimitMemory(50%)`** — dropped. The percentage resolves against **host** physical RAM (ImageMagick reads `sysconf`, not the cgroup), so on the 4Gi-limited pod it resolved to ~50% of host (tens of GB) and never bounded the container — false safety; the cgroup OOM-kills at 4Gi long before it trips. Not an issue today (only 256×256 Q8 tiles flow → tiny pixel cache). A container-aware **absolute** limit, for if larger images are ever processed, is tracked in **MAPCO-11366**.

## Scope note
The hygiene ticket also lists renames / dead-code / DI dedup:
- **DI dedup** — app registrations were checked; there are no duplicates (`Program.cs` registrations are distinct from `RegisterMergerLogicType`).
- **Renames / dead-code** — deferred. This branch merges last and broad renames/removals would churn the same files the sibling MAPCO-11317 PRs (#255–#258, SVC-1) touch, creating avoidable conflicts. Kept to the self-contained resource-limit wins.

## Testing
Full suite: **1141 passed, 0 failed** (`Thread=1` is perf-only; golden-image tests unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
