### PR TITLE
perf(fs): probe tile extensions with File.Exists instead of directory glob (MAPCO-11364 P14)

### DIFF
--- a/MergerLogic/Clients/FileClient.cs
+++ b/MergerLogic/Clients/FileClient.cs
@@ -38,9 +38,7 @@ public class FileClient : DataUtils, IFileClient
 
     private string? GetTilePath(int z, int x, int y)
     {
-        // Probe the known extensions directly instead of globbing the directory: File.Exists returns
-        // false for a missing tile or missing directory, so no DirectoryNotFound handling is needed.
-        // TileFormat is the source of truth for the supported extensions (declaration order = probe order).
+        // Probe each supported extension via File.Exists (false for a missing dir too, so no glob/catch).
         foreach (TileFormat format in Enum.GetValues<TileFormat>())
         {
             string candidate = this._fileSystem.Path.Combine(

--- a/MergerLogic/Clients/FileClient.cs
+++ b/MergerLogic/Clients/FileClient.cs
@@ -1,5 +1,6 @@
 using MergerLogic.Batching;
 using MergerLogic.ImageProcessing;
+using System;
 using System.IO.Abstractions;
 using MergerLogic.Utils;
 
@@ -39,7 +40,8 @@ public class FileClient : DataUtils, IFileClient
     {
         // Probe the known extensions directly instead of globbing the directory: File.Exists returns
         // false for a missing tile or missing directory, so no DirectoryNotFound handling is needed.
-        foreach (TileFormat format in new[] { TileFormat.Jpeg, TileFormat.Png })
+        // TileFormat is the source of truth for the supported extensions (declaration order = probe order).
+        foreach (TileFormat format in Enum.GetValues<TileFormat>())
         {
             string candidate = this._fileSystem.Path.Combine(
                 this.path, z.ToString(), x.ToString(), $"{y}.{format.ToString().ToLower()}");

--- a/MergerLogic/Clients/FileClient.cs
+++ b/MergerLogic/Clients/FileClient.cs
@@ -1,4 +1,5 @@
 using MergerLogic.Batching;
+using MergerLogic.ImageProcessing;
 using System.IO.Abstractions;
 using MergerLogic.Utils;
 
@@ -36,16 +37,18 @@ public class FileClient : DataUtils, IFileClient
 
     private string? GetTilePath(int z, int x, int y)
     {
-        var tilePath = this._fileSystem.Path.Join(z.ToString(), x.ToString(), y.ToString());
-        try
+        // Probe the known extensions directly instead of globbing the directory: File.Exists returns
+        // false for a missing tile or missing directory, so no DirectoryNotFound handling is needed.
+        foreach (TileFormat format in new[] { TileFormat.Jpeg, TileFormat.Png })
         {
-            //this may or may not be faster then checking specific files of every supported type depending on the used file system
-            return this._fileSystem.Directory
-                .EnumerateFiles(this.path, $"{tilePath}.*", SearchOption.TopDirectoryOnly).FirstOrDefault();
+            string candidate = this._fileSystem.Path.Combine(
+                this.path, z.ToString(), x.ToString(), $"{y}.{format.ToString().ToLower()}");
+            if (this._fileSystem.File.Exists(candidate))
+            {
+                return candidate;
+            }
         }
-        catch (DirectoryNotFoundException)
-        {
-            return null;
-        }
+
+        return null;
     }
 }

--- a/MergerLogic/ImageProcessing/ImageFormatter.cs
+++ b/MergerLogic/ImageProcessing/ImageFormatter.cs
@@ -5,8 +5,8 @@ namespace MergerLogic.ImageProcessing
 {
     public enum TileFormat
     {
-        [EnumMember(Value = "png")] Png,
         [EnumMember(Value = "jpeg")] Jpeg,
+        [EnumMember(Value = "png")] Png,
     }
 
     public class TileFormatStrategy {

--- a/MergerLogicUnitTests/Clients/FileClientTest.cs
+++ b/MergerLogicUnitTests/Clients/FileClientTest.cs
@@ -68,25 +68,12 @@ namespace MergerLogicUnitTests.Clients
             Coord cords = new Coord(1, 2, 3);
             byte[] data = targetFormat == TileFormat.Jpeg ? this._jpegImageData : this._pngImageData;
 
-            var seq = new MockSequence();
-            this._pathMock
-                .InSequence(seq)
-                .Setup(util => util.Join(cords.Z.ToString(), cords.X.ToString(), cords.Y.ToString()))
-                .Returns("testTilePath");
-            this._directoryMock
-                .InSequence(seq)
-                .Setup(dir => dir.EnumerateFiles("testFilePath", "testTilePath.*", SearchOption.TopDirectoryOnly))
-                .Returns(returnsNull ? Array.Empty<string>() : new string[] { "testTilePath" });
+            SetupTilePathProbe(cords, returnsNull, targetFormat, out string? foundPath);
             if (!returnsNull)
             {
                 this._fileMock
-                    .InSequence(seq)
-                    .Setup(util => util.ReadAllBytes("testTilePath"))
+                    .Setup(util => util.ReadAllBytes(foundPath))
                     .Returns(data);
-                this._imageFormatterMock
-                    .InSequence(seq)
-                    .Setup(formatter => formatter.GetTileFormat(data))
-                    .Returns(targetFormat);
             }
 
             var fileClient = new FileClient("testFilePath", this._geoUtilsMock.Object, this._fsMock.Object);
@@ -107,6 +94,31 @@ namespace MergerLogicUnitTests.Clients
             this._repository.VerifyAll();
         }
 
+        // GetTilePath probes jpeg then png via File.Exists. Sets up only the calls the probe actually
+        // makes: png is not probed once jpeg is found, so its setups are omitted (strict mocks).
+        private void SetupTilePathProbe(Coord cords, bool missing, TileFormat targetFormat, out string? foundPath)
+        {
+            string jpegPath = "1/2/3.jpeg";
+            string pngPath = "1/2/3.png";
+            bool jpegExists = !missing && targetFormat == TileFormat.Jpeg;
+            bool pngExists = !missing && targetFormat == TileFormat.Png;
+
+            this._pathMock
+                .Setup(p => p.Combine("testFilePath", cords.Z.ToString(), cords.X.ToString(), $"{cords.Y}.jpeg"))
+                .Returns(jpegPath);
+            this._fileMock.Setup(f => f.Exists(jpegPath)).Returns(jpegExists);
+
+            if (!jpegExists)
+            {
+                this._pathMock
+                    .Setup(p => p.Combine("testFilePath", cords.Z.ToString(), cords.X.ToString(), $"{cords.Y}.png"))
+                    .Returns(pngPath);
+                this._fileMock.Setup(f => f.Exists(pngPath)).Returns(pngExists);
+            }
+
+            foundPath = jpegExists ? jpegPath : (pngExists ? pngPath : null);
+        }
+
         #endregion
 
         #region TileExists
@@ -117,46 +129,14 @@ namespace MergerLogicUnitTests.Clients
         public void TileExists(bool exist)
         {
             Coord cords = new Coord(1, 2, 3);
-            byte[] data = this._jpegImageData;
 
-            var seq = new MockSequence();
-            this._pathMock
-                .InSequence(seq)
-                .Setup(util => util.Join(cords.Z.ToString(), cords.X.ToString(), cords.Y.ToString()))
-                .Returns("testTilePath");
-            this._directoryMock
-                .InSequence(seq)
-                .Setup(dir => dir.EnumerateFiles("testFilePath", "testTilePath.*", SearchOption.TopDirectoryOnly))
-                .Returns(exist ? new string[] { "testFile" } : Array.Empty<string>());
+            SetupTilePathProbe(cords, !exist, TileFormat.Jpeg, out _);
 
             var fileClient = new FileClient("testFilePath", this._geoUtilsMock.Object, this._fsMock.Object);
 
             var res = fileClient.TileExists(cords.Z, cords.X, cords.Y);
 
             Assert.AreEqual(exist, res);
-            this._repository.VerifyAll();
-        }
-
-        [TestMethod]
-        public void TileExistsReturnFalseWhenDirectoryDontExist()
-        {
-            Coord cords = new Coord(1, 2, 3);
-
-            var seq = new MockSequence();
-            this._pathMock
-                .InSequence(seq)
-                .Setup(util => util.Join(cords.Z.ToString(), cords.X.ToString(), cords.Y.ToString()))
-                .Returns("testTilePath");
-            this._directoryMock
-                .InSequence(seq)
-                .Setup(dir => dir.EnumerateFiles("testFilePath", "testTilePath.*", SearchOption.TopDirectoryOnly))
-                .Throws<DirectoryNotFoundException>();
-
-            var fileClient = new FileClient("testFilePath", this._geoUtilsMock.Object, this._fsMock.Object);
-
-            var res = fileClient.TileExists(cords.Z, cords.X, cords.Y);
-
-            Assert.AreEqual(false, res);
             this._repository.VerifyAll();
         }
 


### PR DESCRIPTION
P14 of MAPCO-11364 (LOGIC-3 I/O follow-up). **Stacked on #257 (`logic-3-io-async`)** — retarget to master after #257 merges.

## Change
`FileClient.GetTilePath` (used by `GetTile` and `TileExists`) globbed the directory with `EnumerateFiles(path, "{z}/{x}/{y}.*")` on every call. Replaced with direct `File.Exists` probes of the supported extensions — jpeg then png.

- `File.Exists` returns false for both a missing tile and a missing directory, so the `DirectoryNotFoundException` catch is no longer needed and is removed.
- The probe set is sourced from `Enum.GetValues<TileFormat>()` — the `TileFormat` enum is the single source of truth, so a new format is covered automatically (no hardcoded array).

## Cross-cutting: TileFormat enum reordered
`TileFormat` is reordered `Jpeg, Png` (was `Png, Jpeg`) so declaration order — which is now the probe order via `Enum.GetValues` — keeps **jpeg first**, matching the S3 client's historical probe order.

- Verified no int-value coupling on `TileFormat`: no `(int)` casts, no `default(TileFormat)` reliance, no ordinal indexing. All 11 usages are explicit `.Jpeg`/`.Png`. The reorder is behavior-preserving.
- Full MergerLogic suite (1117) and MergerService suite (23) both green after the reorder.

## Follow-up
The extension **string** is still derived from `format.ToString().ToLower()` (here and in `PathUtils`), which only coincidentally equals the `[EnumMember]` value. Tracked as **MAPCO-11369** (make the `EnumMember` value the source of truth for the extension).

## Tests
- `GetTile` / `TileExists` now mock `Path.Combine` + `File.Exists` via a shared `SetupTilePathProbe` helper (png setups omitted when jpeg is found, per strict mocks).
- `TileExistsReturnFalseWhenDirectoryDontExist` removed — `File.Exists` never throws on a missing directory, so the scenario collapses into the normal "not found → false" case.
- FileClient suite: **10 passed, 0 failed**.

## Scope
Only `FileClient` (+ the `TileFormat` reorder). Sibling 11364 items (P5r, P11, P10r, P15, P4) are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)