### PR TITLE
perf(s3): discover zoom levels with one delimited LIST instead of 25 probes (MAPCO-11364 P11)

### DIFF
--- a/MergerLogic/DataTypes/S3.cs
+++ b/MergerLogic/DataTypes/S3.cs
@@ -5,6 +5,7 @@ using MergerLogic.Clients;
 using MergerLogic.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Reflection;
 
 namespace MergerLogic.DataTypes
@@ -67,15 +68,31 @@ namespace MergerLogic.DataTypes
         private List<int> GetZoomLevels()
         {
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] start");
-            List<int> zoomLevels = new List<int>();
 
-            for (int zoomLevel = 0; zoomLevel < Data<IS3Client>.MaxZoomRead; zoomLevel++)
+            // One delimited LIST returns the immediate zoom-level "folders" as CommonPrefixes,
+            // replacing the previous per-level probe (one LIST for each of the 0..MaxZoomRead levels).
+            var listRequest = new ListObjectsV2Request
             {
-                if (this.FolderExists($"{zoomLevel}/"))
+                BucketName = this._bucket,
+                Prefix = $"{this.Path}/",
+                Delimiter = "/"
+            };
+            var response = this._client.ListObjectsV2Async(listRequest).Result;
+
+            List<int> zoomLevels = new List<int>();
+            foreach (string prefix in response.CommonPrefixes ?? Enumerable.Empty<string>())
+            {
+                // prefix is "{Path}/{zoom}/" — take the last path segment
+                string zoomSegment = prefix.TrimEnd('/').Split('/').Last();
+                if (int.TryParse(zoomSegment, out int zoomLevel) && zoomLevel < Data<IS3Client>.MaxZoomRead)
                 {
                     zoomLevels.Add(zoomLevel);
                 }
             }
+
+            // CommonPrefixes come back lexicographically ("10/" before "2/"); the read path expects
+            // ascending numeric zoom order.
+            zoomLevels.Sort();
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] ended");
             return zoomLevels;
         }

--- a/MergerLogic/DataTypes/S3.cs
+++ b/MergerLogic/DataTypes/S3.cs
@@ -69,8 +69,6 @@ namespace MergerLogic.DataTypes
         {
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] start");
 
-            // One delimited LIST returns the immediate zoom-level "folders" as CommonPrefixes,
-            // replacing the previous per-level probe (one LIST for each of the 0..MaxZoomRead levels).
             var listRequest = new ListObjectsV2Request
             {
                 BucketName = this._bucket,
@@ -82,7 +80,6 @@ namespace MergerLogic.DataTypes
             List<int> zoomLevels = new List<int>();
             foreach (string prefix in response.CommonPrefixes ?? Enumerable.Empty<string>())
             {
-                // prefix is "{Path}/{zoom}/" — take the last path segment
                 string zoomSegment = prefix.TrimEnd('/').Split('/').Last();
                 if (int.TryParse(zoomSegment, out int zoomLevel) && zoomLevel < Data<IS3Client>.MaxZoomRead)
                 {
@@ -90,8 +87,7 @@ namespace MergerLogic.DataTypes
                 }
             }
 
-            // CommonPrefixes come back lexicographically ("10/" before "2/"); the read path expects
-            // ascending numeric zoom order.
+            // CommonPrefixes sort lexicographically ("10/" before "2/"); the read path needs numeric order.
             zoomLevels.Sort();
             this._logger.LogDebug($"[{MethodBase.GetCurrentMethod()?.Name}] ended");
             return zoomLevels;

--- a/MergerLogic/DataTypes/S3.cs
+++ b/MergerLogic/DataTypes/S3.cs
@@ -81,7 +81,8 @@ namespace MergerLogic.DataTypes
             foreach (string prefix in response.CommonPrefixes ?? Enumerable.Empty<string>())
             {
                 string zoomSegment = prefix.TrimEnd('/').Split('/').Last();
-                if (int.TryParse(zoomSegment, out int zoomLevel) && zoomLevel < Data<IS3Client>.MaxZoomRead)
+                bool parsed = int.TryParse(zoomSegment, out int zoomLevel);
+                if (parsed && zoomLevel < Data<IS3Client>.MaxZoomRead)
                 {
                     zoomLevels.Add(zoomLevel);
                 }

--- a/MergerLogicUnitTests/DataTypes/S3Test.cs
+++ b/MergerLogicUnitTests/DataTypes/S3Test.cs
@@ -691,6 +691,8 @@ namespace MergerLogicUnitTests.DataTypes
                 .Setup(s3 => s3.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ListObjectsV2Response()
                 {
+                    // serves both the ctor zoom-discovery (CommonPrefixes) and the batch reads (S3Objects)
+                    CommonPrefixes = new List<string>() { "test/0/" },
                     S3Objects = new List<S3Object>()
                     {
                         new S3Object(),
@@ -1015,33 +1017,31 @@ namespace MergerLogicUnitTests.DataTypes
         {
             var seq = sequence ?? new MockSequence();
 
-            ListObjectsV2Response res = new ListObjectsV2Response() { KeyCount = exists ? 1 : 0 };
+            // base ctor Exists() check
             this._s3ClientMock
                 .InSequence(seq)
                 .Setup(s3 => s3.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(res);
+                .ReturnsAsync(new ListObjectsV2Response() { KeyCount = exists ? 1 : 0 });
 
-            // Mock existance check for each zoom level until MaxZoomRead
+            // GetZoomLevels() — one delimited LIST returns the zoom-level folders as CommonPrefixes
+            var zoomPrefixes = new List<string>();
             for (int i = 0; i < Data<IS3Client>.MaxZoomRead; i++)
             {
-                this._s3ClientMock
-                    .InSequence(seq)
-                    .Setup(s3 => s3.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), It.IsAny<CancellationToken>()))
-                    .ReturnsAsync(new ListObjectsV2Response() { KeyCount = 1 });
+                zoomPrefixes.Add($"test/{i}/");
             }
+            this._s3ClientMock
+                .InSequence(seq)
+                .Setup(s3 => s3.ListObjectsV2Async(It.IsAny<ListObjectsV2Request>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ListObjectsV2Response() { CommonPrefixes = zoomPrefixes });
         }
 
         private void VerifyConstructorRequiredMocks()
         {
-            for (int z = 0; z < Data<IS3Client>.MaxZoomRead; z++)
-            {
-                this._s3ClientMock.Verify(s3 => s3.ListObjectsV2Async(It.Is<ListObjectsV2Request>(req =>
-                    req.BucketName == "bucket" &&
-                    req.Prefix == $"test/{z}/" &&
-                    req.StartAfter == $"test/{z}/" &&
-                    req.MaxKeys == 1
-                ), It.IsAny<CancellationToken>()), Times.Once);
-            }
+            this._s3ClientMock.Verify(s3 => s3.ListObjectsV2Async(It.Is<ListObjectsV2Request>(req =>
+                req.BucketName == "bucket" &&
+                req.Prefix == "test/" &&
+                req.Delimiter == "/"
+            ), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         private void VerifyAll()


### PR DESCRIPTION
P11 of MAPCO-11364 (LOGIC-3 I/O follow-up). **Stacked on #257 (`logic-3-io-async`)** — retarget to master after #257 merges.

## Change
`S3.GetZoomLevels` discovered the source's zoom set by probing every level `0..MaxZoomRead` with its own `FolderExists` LIST — **25 round-trips on every S3 source construction**.

Replaced with a single `ListObjectsV2` using `Delimiter="/"`, which returns the immediate zoom-level "folders" as `CommonPrefixes`. Each prefix (`{path}/{z}/`) is parsed to its zoom int.

- Results are **numeric-sorted**: `CommonPrefixes` come back lexicographically (`"10/"` sorts before `"2/"`), but the read path (zoom enumerator) expects ascending numeric order.
- Levels `>= MaxZoomRead` are filtered out, preserving the old cap.
- `CommonPrefixes` is null-guarded (`?? Enumerable.Empty<string>()`) for defensiveness against hand-built responses.

`FolderExists` is retained — still used by `Exists()`.

## Tests
- Ctor mock helper now returns a `CommonPrefixes` response for zoom discovery (one LIST) instead of `MaxZoomRead` `KeyCount` responses; `VerifyConstructorRequiredMocks` collapses to a single delimited-LIST assertion.
- `Reset`'s catch-all response gains `CommonPrefixes` so zoom discovery still yields a level.
- S3Test: **102 passed**; full MergerLogic suite: **1118 passed, 0 failed**.

## Scope
Only `S3.GetZoomLevels`. Sibling 11364 items (P5r, P14, P10r, P15, P4) are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)